### PR TITLE
bugfixes: Fixes to get tests and the service working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ test-short:
 		-v $(PWD):/go/src/concord-controller \
 		-v $(PWD)/.src:/go/src \
 		-w /go/src/concord-controller \
-		golang /bin/sh -c "go get -v -t -d && go test -short -v"
+		golang /bin/sh -c "go get -v -t -d && go test -short -v -coverprofile=.coverage.out"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 		-w /usr/src/concord-controller \
 		golang /bin/sh -c "go get -v -d && go build -a -installsuffix cgo -o main"
 	@docker build -t concord/controller .
-	@rm main
+	@rm -f main
 
 .PHONY: mock
 mock: 

--- a/api_test.go
+++ b/api_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/bitwurx/jrpc2"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -53,7 +53,7 @@ func TestAp1V1AddResource(t *testing.T) {
 		models := map[string]Model{"resources": rescModel, "tasks": taskModel}
 		ctrl := &MockController{}
 		ctrl.On("AddResource", tt.Name, rescModel).Return(tt.CallErr)
-		api := NewApiV1(models, ctrl, jrpc2.NewServer("", ""))
+		api := NewApiV1(models, ctrl, jrpc2.NewServer("", "", nil))
 		result, errObj := api.AddResource(tt.Body)
 		if errObj != nil && errObj.Code != tt.ErrCode && errObj.Message != tt.ErrMsg {
 			t.Fatal(errObj.Message)
@@ -121,7 +121,7 @@ func TestAp1V1AddTask(t *testing.T) {
 		models := map[string]Model{"tasks": taskModel, "resources": rescModel}
 		ctrl := &MockController{}
 		ctrl.On("AddTask", mock.AnythingOfType("*main.Task"), taskModel, rescModel).Return(tt.CallErr)
-		api := NewApiV1(models, ctrl, jrpc2.NewServer("", ""))
+		api := NewApiV1(models, ctrl, jrpc2.NewServer("", "", nil))
 		result, errObj := api.AddTask(tt.Body)
 		if errObj != nil && errObj.Code != tt.ErrCode && errObj.Message != tt.ErrMsg {
 			t.Fatal(errObj.Message)
@@ -233,7 +233,7 @@ func TestAp1V1CompleteTask(t *testing.T) {
 		ctrl := &MockController{}
 		ctrl.On("CompleteTask", tt.TaskId, mock.AnythingOfType("string"), taskModel, rescModel).Return(tt.CallErr)
 		models := map[string]Model{"resources": rescModel, "tasks": taskModel}
-		api := NewApiV1(models, ctrl, jrpc2.NewServer("", ""))
+		api := NewApiV1(models, ctrl, jrpc2.NewServer("", "", nil))
 		result, errObj := api.CompleteTask(tt.Body)
 		if errObj != nil && errObj.Code != tt.ErrCode && errObj.Message != tt.ErrMsg {
 			t.Fatal(errObj.Message)
@@ -283,7 +283,7 @@ func TestAp1V1GetTask(t *testing.T) {
 		models := map[string]Model{"resources": rescModel, "tasks": taskModel}
 		ctrl := &MockController{}
 		ctrl.On("GetTask", tt.TaskId, taskModel).Return(tt.Result, tt.Err)
-		api := NewApiV1(models, ctrl, jrpc2.NewServer("", ""))
+		api := NewApiV1(models, ctrl, jrpc2.NewServer("", "", nil))
 		result, errObj := api.GetTask(tt.Body)
 		if errObj != nil && errObj.Code != tt.ErrCode && errObj.Message != tt.ErrMsg {
 			t.Fatal(errObj.Message)
@@ -365,7 +365,7 @@ func TestApiV1ListPriorityQueue(t *testing.T) {
 		models := map[string]Model{"resources": rescModel, "tasks": taskModel}
 		ctrl := &MockController{}
 		ctrl.On("ListPriorityQueue", tt.Key).Return(tt.Result, tt.Err)
-		api := NewApiV1(models, ctrl, jrpc2.NewServer("", ""))
+		api := NewApiV1(models, ctrl, jrpc2.NewServer("", "", nil))
 		result, errObj := api.ListPriorityQueue(tt.Body)
 		if errObj != nil && errObj.Code != tt.ErrCode && errObj.Message != tt.ErrMsg {
 			t.Fatal(errObj.Message)
@@ -447,7 +447,7 @@ func TestApiV1ListTimetable(t *testing.T) {
 		models := map[string]Model{"resources": rescModel, "tasks": taskModel}
 		ctrl := &MockController{}
 		ctrl.On("ListTimetable", tt.Key).Return(tt.Result, tt.Err)
-		api := NewApiV1(models, ctrl, jrpc2.NewServer("", ""))
+		api := NewApiV1(models, ctrl, jrpc2.NewServer("", "", nil))
 		result, errObj := api.ListTimetable(tt.Body)
 		if errObj != nil && errObj.Code != tt.ErrCode && errObj.Message != tt.ErrMsg {
 			t.Fatal(errObj.Message)
@@ -513,7 +513,7 @@ func TestAp1V1RemoveTask(t *testing.T) {
 		models := map[string]Model{"tasks": taskModel, "resources": rescModel}
 		ctrl := &MockController{}
 		ctrl.On("RemoveTask", tt.Id, taskModel).Return(tt.CallErr).Once()
-		api := NewApiV1(models, ctrl, jrpc2.NewServer("", ""))
+		api := NewApiV1(models, ctrl, jrpc2.NewServer("", "", nil))
 		result, errObj := api.RemoveTask(tt.Body)
 		if errObj != nil && errObj.Code != tt.ErrCode && errObj.Message != tt.ErrMsg {
 			t.Fatal(errObj.Message)
@@ -609,7 +609,7 @@ func TestAp1V1StartTask(t *testing.T) {
 		ctrl := &MockController{}
 		ctrl.On("StartTask", tt.Key, taskModel, rescModel).Return(tt.CallErr)
 		models := map[string]Model{"resources": rescModel, "tasks": taskModel}
-		api := NewApiV1(models, ctrl, jrpc2.NewServer("", ""))
+		api := NewApiV1(models, ctrl, jrpc2.NewServer("", "", nil))
 		result, errObj := api.StartTask(tt.Body)
 		if errObj != nil && errObj.Code != tt.ErrCode && errObj.Message != tt.ErrMsg {
 			t.Fatal(errObj.Message)

--- a/api_test.go
+++ b/api_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/bitwurx/jrpc2"
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/controller_test.go
+++ b/controller_test.go
@@ -57,7 +57,7 @@ func TestServiceBrokerCall(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	s := jrpc2.NewServer(":7777", "/rpc")
+	s := jrpc2.NewServer(":7777", "/rpc", nil)
 	s.Register("add", jrpc2.Method{Method: AddMethod})
 	go s.Start()
 	wg.Add(1)

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 
 func main() {
 	InitDatabase()
-	s := jrpc2.NewServer(":8080", "/rpc")
+	s := jrpc2.NewServer(":8080", "/rpc", nil)
 	models := map[string]Model{
 		"resources": &ResourceModel{},
 		"tasks":     &TaskModel{},

--- a/tasks.go
+++ b/tasks.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (

--- a/tasks.go
+++ b/tasks.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 const (

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 func TestNewTaskStat(t *testing.T) {

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 func TestNewTaskStat(t *testing.T) {


### PR DESCRIPTION
Fixes issues with the jrpc2 library needing an additional argument.
Adds coverage to all "make test" calls
Removes are you sure step during make build
Switches to using the Go commune maintained uuid library